### PR TITLE
Don't crash cache if we serve a debug response in network-interceptor…

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,13 @@
+### 1.4.0 ###
+
+* Don't crash cache if we serve a debug response in network-interceptor mode. Fixes #20
+* Add metadata to protocol to send agnostic metadata to the plugin. Replaces injected headers.
+* Check if a response was served purely from cache and mark it as such in the metadata. Fixes #19
+
+### 1.3.x ###
+
+* Minor enhancements
+
 ### 1.2.0 ###
 
 * Added an option to the okhttp interceptor to also report downstream exceptions

--- a/constants.gradle
+++ b/constants.gradle
@@ -1,3 +1,3 @@
 project.ext {
-    releaseVersion = '1.3.3'
+    releaseVersion = '1.4.0'
 }

--- a/niddler-example-android/src/main/java/com/icapps/sampleapplication/NiddlerSampleApplication.kt
+++ b/niddler-example-android/src/main/java/com/icapps/sampleapplication/NiddlerSampleApplication.kt
@@ -8,10 +8,12 @@ import com.icapps.niddler.retrofit.NiddlerRetrofitCallInjector
 import com.icapps.sampleapplication.api.ExampleJsonApi
 import com.icapps.sampleapplication.api.ExampleXMLApi
 import com.icapps.sampleapplication.api.TimeoutApi
+import okhttp3.Cache
 
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.io.File
 import java.util.concurrent.TimeUnit
 
 /**
@@ -43,6 +45,7 @@ class NiddlerSampleApplication : Application() {
                 .readTimeout(3, TimeUnit.SECONDS)
                 .connectTimeout(3, TimeUnit.SECONDS)
                 .writeTimeout(3, TimeUnit.SECONDS)
+                .cache(Cache(cacheDir,10485760L))
                 .addInterceptor(okHttpInterceptor)
                 .build()
 

--- a/niddler-lib-base-noop/src/main/java/com/icapps/niddler/core/NiddlerMessageBase.java
+++ b/niddler-lib-base-noop/src/main/java/com/icapps/niddler/core/NiddlerMessageBase.java
@@ -5,20 +5,50 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
+import androidx.annotation.NonNull;
+
 /**
  * @author Nicola Verbeeck
  * Date 10/11/16.
  */
 public interface NiddlerMessageBase {
 
+	/**
+	 * @return The id of the message. MUST BE unique for every message
+	 */
+	@NonNull
 	String getMessageId();
 
+	/**
+	 * @return The request id of the message. Should be the same for all (logically) linked messages. Eg: requests and responses must share the same request tid
+	 */
+	@NonNull
 	String getRequestId();
 
+	/**
+	 * @return The system timestamp in milliseconds since epoch when the message was sent/created
+	 */
 	long getTimestamp();
 
+	/**
+	 * @return The headers involved in the message
+	 */
+	@NonNull
 	Map<String, List<String>> getHeaders();
 
-	void writeBody(final OutputStream stream) throws IOException;
+	/**
+	 * @return Key-value meta-data to include in the message. Protocol specific meta-data keys start with 'X-Niddler-'. This prefix MUST NOT be used in client code as it will
+	 * be stripped before showing in the UI. Null keys or values are NOT supported
+	 */
+	@NonNull
+	Map<String, String> getMetadata();
+
+	/**
+	 * Write the message body to the given stream
+	 *
+	 * @param stream The stream to write to
+	 * @throws IOException Can be thrown if writing fails
+	 */
+	void writeBody(@NonNull final OutputStream stream) throws IOException;
 
 }

--- a/niddler-lib-base-noop/src/main/java/com/icapps/niddler/core/NiddlerRequest.java
+++ b/niddler-lib-base-noop/src/main/java/com/icapps/niddler/core/NiddlerRequest.java
@@ -1,5 +1,6 @@
 package com.icapps.niddler.core;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.List;
@@ -10,13 +11,27 @@ import java.util.List;
  */
 public interface NiddlerRequest extends NiddlerMessageBase {
 
+	/**
+	 * @return The logical URL of this request
+	 */
+	@NonNull
 	String getUrl();
 
+	/**
+	 * @return The logical method of this request.
+	 */
+	@NonNull
 	String getMethod();
 
+	/**
+	 * @return Associated request-site stack trace if available/configured
+	 */
 	@Nullable
 	StackTraceElement[] getRequestStackTrace();
 
+	/**
+	 * @return Optional request context to display in the UI
+	 */
 	@Nullable
 	List<String> getRequestContext();
 

--- a/niddler-lib-base-noop/src/main/java/com/icapps/niddler/core/NiddlerResponse.java
+++ b/niddler-lib-base-noop/src/main/java/com/icapps/niddler/core/NiddlerResponse.java
@@ -9,27 +9,55 @@ import androidx.annotation.Nullable;
  */
 public interface NiddlerResponse extends NiddlerMessageBase {
 
+	/**
+	 * @return The status code of the response. Eg: For HTTP this is the HTTP response code
+	 */
+	@NonNull
 	Integer getStatusCode();
 
+	/**
+	 * @return The status line (message) of the response. Eg: For HTTP this is the HTTP response message
+	 */
 	@NonNull
 	String getStatusLine();
 
+	/**
+	 * @return The http version used to handle the request. Can be empty if the protocol is not using http
+	 */
 	@NonNull
 	String getHttpVersion();
 
+	/**
+	 * @return If set, the actual request that was sent over the network
+	 */
 	@Nullable
 	NiddlerRequest actualNetworkRequest();
 
+	/**
+	 * @return If set, the actual response that was sent over the network
+	 */
 	@Nullable
 	NiddlerResponse actualNetworkReply();
 
+	/**
+	 * @return If set, the stacktrace of an exception that was thrown during the execution of the request
+	 */
 	@Nullable
 	StackTraceElement[] getErrorStackTrace();
 
+	/**
+	 * @return The time, in milliseconds, it took for the request to write to the network. Use -1 if unknown
+	 */
 	int getWriteTime();
 
+	/**
+	 * @return The time, in milliseconds, it took for the response to read from the network. Use -1 if unknown
+	 */
 	int getReadTime();
 
+	/**
+	 * @return The time, in milliseconds, it took for the response to arrive after it was written to the network. Use -1 if unknown
+	 */
 	int getWaitTime();
 
 }

--- a/niddler-lib-base/src/main/java/com/icapps/niddler/core/MessageBuilder.java
+++ b/niddler-lib-base/src/main/java/com/icapps/niddler/core/MessageBuilder.java
@@ -175,6 +175,7 @@ final class MessageBuilder {
 		object.put("requestId", base.getRequestId());
 		object.put("timestamp", base.getTimestamp());
 		object.put("headers", createHeadersObject(base));
+		object.put("metadata", createMetadataObject(base));
 		object.put("body", createBody(base));
 	}
 
@@ -207,6 +208,19 @@ final class MessageBuilder {
 				array.put(s);
 			}
 			object.put(headerEntry.getKey().toLowerCase(Locale.getDefault()), array);
+		}
+		return object;
+	}
+
+	private static JSONObject createMetadataObject(final NiddlerMessageBase base) throws JSONException {
+		final Map<String, String> headers = base.getMetadata();
+		if (headers == null || headers.isEmpty()) {
+			return null;
+		}
+
+		final JSONObject object = new JSONObject();
+		for (final Map.Entry<String, String> entry : headers.entrySet()) {
+			object.put(entry.getKey(), entry.getValue());
 		}
 		return object;
 	}

--- a/niddler-lib-base/src/main/java/com/icapps/niddler/core/Niddler.java
+++ b/niddler-lib-base/src/main/java/com/icapps/niddler/core/Niddler.java
@@ -23,9 +23,10 @@ import java.util.regex.Pattern;
 @SuppressWarnings("WeakerAccess")
 public abstract class Niddler implements Closeable {
 
-	public static final String NIDDLER_DEBUG_RESPONSE_HEADER = "X-Niddler-Debug";
-	public static final String NIDDLER_DEBUG_TIMING_RESPONSE_HEADER = "X-Niddler-Debug-Timing";
+	public static final String NIDDLER_DEBUG_RESPONSE_METADATA = "X-Niddler-Debug";
+	public static final String NIDDLER_DEBUG_TIMING_RESPONSE_METADATA= "X-Niddler-Debug-Timing";
 	public static final String INTENT_EXTRA_WAIT_FOR_DEBUGGER = "Niddler-Wait-For-Debugger";
+	public static final String NIDDLER_FROM_DISK_METADATA = "X-Niddler-FromDiskCache";
 	private static final int MAX_TRACE_CACHE_SIZE = 100;
 
 	private final LinkedHashMap<StackTraceKey, StackTraceElement[]> mStackTraceMap;

--- a/niddler-lib-base/src/main/java/com/icapps/niddler/core/NiddlerMessageBase.java
+++ b/niddler-lib-base/src/main/java/com/icapps/niddler/core/NiddlerMessageBase.java
@@ -5,20 +5,50 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
+import androidx.annotation.NonNull;
+
 /**
  * @author Nicola Verbeeck
  * Date 10/11/16.
  */
 public interface NiddlerMessageBase {
 
+	/**
+	 * @return The id of the message. MUST BE unique for every message
+	 */
+	@NonNull
 	String getMessageId();
 
+	/**
+	 * @return The request id of the message. Should be the same for all (logically) linked messages. Eg: requests and responses must share the same request tid
+	 */
+	@NonNull
 	String getRequestId();
 
+	/**
+	 * @return The system timestamp in milliseconds since epoch when the message was sent/created
+	 */
 	long getTimestamp();
 
+	/**
+	 * @return The headers involved in the message
+	 */
+	@NonNull
 	Map<String, List<String>> getHeaders();
 
-	void writeBody(final OutputStream stream) throws IOException;
+	/**
+	 * @return Key-value meta-data to include in the message. Protocol specific meta-data keys start with 'X-Niddler-'. This prefix MUST NOT be used in client code as it will
+	 * be stripped before showing in the UI. Null keys or values are NOT supported
+	 */
+	@NonNull
+	Map<String, String> getMetadata();
+
+	/**
+	 * Write the message body to the given stream
+	 *
+	 * @param stream The stream to write to
+	 * @throws IOException Can be thrown if writing fails
+	 */
+	void writeBody(@NonNull final OutputStream stream) throws IOException;
 
 }

--- a/niddler-lib-base/src/main/java/com/icapps/niddler/core/NiddlerRequest.java
+++ b/niddler-lib-base/src/main/java/com/icapps/niddler/core/NiddlerRequest.java
@@ -1,8 +1,9 @@
 package com.icapps.niddler.core;
 
-import androidx.annotation.Nullable;
-
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * @author Nicola Verbeeck
@@ -10,13 +11,27 @@ import java.util.List;
  */
 public interface NiddlerRequest extends NiddlerMessageBase {
 
+	/**
+	 * @return The logical URL of this request
+	 */
+	@NonNull
 	String getUrl();
 
+	/**
+	 * @return The logical method of this request.
+	 */
+	@NonNull
 	String getMethod();
 
+	/**
+	 * @return Associated request-site stack trace if available/configured
+	 */
 	@Nullable
 	StackTraceElement[] getRequestStackTrace();
 
+	/**
+	 * @return Optional request context to display in the UI
+	 */
 	@Nullable
 	List<String> getRequestContext();
 

--- a/niddler-lib-base/src/main/java/com/icapps/niddler/core/NiddlerResponse.java
+++ b/niddler-lib-base/src/main/java/com/icapps/niddler/core/NiddlerResponse.java
@@ -9,26 +9,54 @@ import androidx.annotation.Nullable;
  */
 public interface NiddlerResponse extends NiddlerMessageBase {
 
+	/**
+	 * @return The status code of the response. Eg: For HTTP this is the HTTP response code
+	 */
+	@NonNull
 	Integer getStatusCode();
 
+	/**
+	 * @return The status line (message) of the response. Eg: For HTTP this is the HTTP response message
+	 */
 	@NonNull
 	String getStatusLine();
 
+	/**
+	 * @return The http version used to handle the request. Can be empty if the protocol is not using http
+	 */
 	@NonNull
 	String getHttpVersion();
 
+	/**
+	 * @return If set, the actual request that was sent over the network
+	 */
 	@Nullable
 	NiddlerRequest actualNetworkRequest();
 
+	/**
+	 * @return If set, the actual response that was sent over the network
+	 */
 	@Nullable
 	NiddlerResponse actualNetworkReply();
 
+	/**
+	 * @return If set, the stacktrace of an exception that was thrown during the execution of the request
+	 */
 	@Nullable
 	StackTraceElement[] getErrorStackTrace();
 
+	/**
+	 * @return The time, in milliseconds, it took for the request to write to the network. Use -1 if unknown
+	 */
 	int getWriteTime();
 
+	/**
+	 * @return The time, in milliseconds, it took for the response to read from the network. Use -1 if unknown
+	 */
 	int getReadTime();
 
+	/**
+	 * @return The time, in milliseconds, it took for the response to arrive after it was written to the network. Use -1 if unknown
+	 */
 	int getWaitTime();
 }

--- a/niddler-lib-base/src/main/java/com/icapps/niddler/interceptor/okhttp/NiddlerOkHttpErrorResponse.java
+++ b/niddler-lib-base/src/main/java/com/icapps/niddler/interceptor/okhttp/NiddlerOkHttpErrorResponse.java
@@ -9,6 +9,7 @@ import java.net.SocketTimeoutException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.UUID;
 
 import androidx.annotation.NonNull;
@@ -24,6 +25,7 @@ final class NiddlerOkHttpErrorResponse implements NiddlerResponse {
 	private final long mTimestamp;
 	private final String mStatusLine;
 	private final StackTraceElement[] mStackTrace;
+	private final Map<String, String> mMetadata;
 
 	NiddlerOkHttpErrorResponse(@NonNull final String requestId, @NonNull final Throwable error) {
 		mRequestId = requestId;
@@ -37,13 +39,26 @@ final class NiddlerOkHttpErrorResponse implements NiddlerResponse {
 		} else {
 			mStatusLine = error.getMessage();
 		}
+		mMetadata = new TreeMap<>();
 	}
 
+	public void addMetadata(@NonNull final String key, @NonNull final String value) {
+		mMetadata.put(key, value);
+	}
+
+	@NonNull
+	@Override
+	public Map<String, String> getMetadata() {
+		return mMetadata;
+	}
+
+	@NonNull
 	@Override
 	public String getMessageId() {
 		return mMessageId;
 	}
 
+	@NonNull
 	@Override
 	public String getRequestId() {
 		return mRequestId;
@@ -54,11 +69,13 @@ final class NiddlerOkHttpErrorResponse implements NiddlerResponse {
 		return mTimestamp;
 	}
 
+	@NonNull
 	@Override
 	public Map<String, List<String>> getHeaders() {
 		return Collections.emptyMap();
 	}
 
+	@NonNull
 	@Override
 	public Integer getStatusCode() {
 		return 0;
@@ -104,7 +121,7 @@ final class NiddlerOkHttpErrorResponse implements NiddlerResponse {
 	}
 
 	@Override
-	public void writeBody(final OutputStream stream) {
+	public void writeBody(@NonNull final OutputStream stream) {
 	}
 
 	@Nullable

--- a/niddler-lib-base/src/main/java/com/icapps/niddler/interceptor/okhttp/NiddlerOkHttpInterceptor.java
+++ b/niddler-lib-base/src/main/java/com/icapps/niddler/interceptor/okhttp/NiddlerOkHttpInterceptor.java
@@ -29,8 +29,9 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
-import static com.icapps.niddler.core.Niddler.NIDDLER_DEBUG_RESPONSE_HEADER;
-import static com.icapps.niddler.core.Niddler.NIDDLER_DEBUG_TIMING_RESPONSE_HEADER;
+import static com.icapps.niddler.core.Niddler.NIDDLER_DEBUG_RESPONSE_METADATA;
+import static com.icapps.niddler.core.Niddler.NIDDLER_DEBUG_TIMING_RESPONSE_METADATA;
+import static com.icapps.niddler.core.Niddler.NIDDLER_FROM_DISK_METADATA;
 
 /**
  * @author Nicola Verbeeck
@@ -162,14 +163,14 @@ public class NiddlerOkHttpInterceptor implements Interceptor {
 
 		final String uuid = UUID.randomUUID().toString();
 
-		final NiddlerRequest origNiddlerRequest = new NiddlerOkHttpRequest(origRequest, uuid, buildExtraNiddlerHeaders(changedTime ? FLAG_TIME : 0), traces, requestContext);
+		final NiddlerRequest origNiddlerRequest = new NiddlerOkHttpRequest(origRequest, uuid, null, traces, requestContext, buildExtraNiddlerMetadata(changedTime ? FLAG_TIME : 0));
 		final NiddlerDebugger.DebugRequest overriddenRequest = mDebugger.overrideRequest(origNiddlerRequest);
 
 		final Request finalRequest = (overriddenRequest == null) ? origRequest : makeRequest(overriddenRequest);
 
 		final NiddlerRequest niddlerRequest = (overriddenRequest == null)
-				? origNiddlerRequest : new NiddlerOkHttpRequest(finalRequest, uuid, buildExtraNiddlerHeaders((changedTime ? FLAG_TIME : 0) + FLAG_MODIFIED_REQUEST), traces,
-				requestContext);
+				? origNiddlerRequest : new NiddlerOkHttpRequest(finalRequest, uuid, null, traces,
+				requestContext, buildExtraNiddlerMetadata((changedTime ? FLAG_TIME : 0) + FLAG_MODIFIED_REQUEST));
 
 		mNiddler.logRequest(niddlerRequest);
 
@@ -194,15 +195,19 @@ public class NiddlerOkHttpInterceptor implements Interceptor {
 		final int readTime = (int) (now - sentAt); //Unknown-ish
 
 		final Response networkResponse = response.networkResponse();
+		final boolean pureFromCache = response.cacheResponse() != null && networkResponse == null;
 		final Request networkRequest = (networkResponse == null) ? null : networkResponse.request();
 
 		changedTime = mDebugger.ensureCallTime(callStartTime);
-		final Map<String, String> extraHeaders = buildExtraNiddlerHeaders((changedTime ? FLAG_TIME : 0) + (debuggerBeforeExecuteOverride != null ? FLAG_MODIFIED_RESPONSE : 0));
+		final Map<String, String> metadata = buildExtraNiddlerMetadata((changedTime ? FLAG_TIME : 0) + (debuggerBeforeExecuteOverride != null ? FLAG_MODIFIED_RESPONSE : 0));
+		if (pureFromCache) {
+			metadata.put(NIDDLER_FROM_DISK_METADATA, "true");
+		}
 
 		final NiddlerResponse niddlerResponse = new NiddlerOkHttpResponse(response, uuid,
-				(networkRequest == null) ? null : new NiddlerOkHttpRequest(networkRequest, uuid, null, null, null),
-				(networkResponse == null) ? null : new NiddlerOkHttpResponse(networkResponse, uuid, null, null, writeTime, readTime, wait, null),
-				writeTime, readTime, wait, extraHeaders);
+				(networkRequest == null) ? null : new NiddlerOkHttpRequest(networkRequest, uuid, null, null, null, null),
+				(networkResponse == null) ? null : new NiddlerOkHttpResponse(networkResponse, uuid, null, null, writeTime, readTime, wait, null, null),
+				writeTime, readTime, wait, null, metadata);
 
 		NiddlerDebugger.DebugResponse debugFromResponse = null;
 		if (debugResponse == null) {
@@ -219,7 +224,8 @@ public class NiddlerOkHttpInterceptor implements Interceptor {
 			final NiddlerResponse debugNiddlerResponse = new NiddlerOkHttpResponse(debugResp, uuid,
 					null,
 					null,
-					writeTime, newReadTime, newWait, buildExtraNiddlerHeaders(FLAG_MODIFIED_RESPONSE + (changedTime ? FLAG_TIME : 0)));
+					writeTime, newReadTime, newWait, null,
+					buildExtraNiddlerMetadata(FLAG_MODIFIED_RESPONSE + (changedTime ? FLAG_TIME : 0)));
 
 			mNiddler.logResponse(debugNiddlerResponse);
 			return debugResp;
@@ -241,9 +247,18 @@ public class NiddlerOkHttpInterceptor implements Interceptor {
 			return null;
 		}
 
-		final Response.Builder builder = new Response.Builder()
+		//By building upon the old response we ensure required fields for cache etc are set
+		//Only relevant if we are a network interceptor instead of an application layer interceptor. We do zero out some data
+		final Response.Builder builder = (response == null ? new Response.Builder() : response.newBuilder())
+				.headers(Headers.of())
+				.body(null)
 				.code(debugResponse.code)
 				.message(debugResponse.message);
+		if (response == null) {
+			if (request.isHttps()) { //This will crash the cache if enabled. Inject fake vary header to prevent saving. Sorry
+				builder.addHeader("Vary", "*");
+			}
+		}
 
 		if (debugResponse.headers != null) {
 			final Headers.Builder headers = new Headers.Builder();
@@ -311,17 +326,17 @@ public class NiddlerOkHttpInterceptor implements Interceptor {
 	}
 
 	@Nullable
-	private static Map<String, String> buildExtraNiddlerHeaders(final int flags) {
+	private static Map<String, String> buildExtraNiddlerMetadata(final int flags) {
 		if (flags == 0) {
 			return null;
 		}
 
 		final Map<String, String> extra = new HashMap<>();
 		if ((flags & FLAG_TIME) != 0) {
-			extra.put(NIDDLER_DEBUG_TIMING_RESPONSE_HEADER, "true");
+			extra.put(NIDDLER_DEBUG_TIMING_RESPONSE_METADATA, "true");
 		}
 		if ((flags & FLAG_MODIFIED_RESPONSE) != 0 || (flags & FLAG_MODIFIED_REQUEST) != 0) {
-			extra.put(NIDDLER_DEBUG_RESPONSE_HEADER, "true");
+			extra.put(NIDDLER_DEBUG_RESPONSE_METADATA, "true");
 		}
 
 		return extra;

--- a/niddler-lib-base/src/main/java/com/icapps/niddler/interceptor/okhttp/NiddlerOkHttpInterceptor.java
+++ b/niddler-lib-base/src/main/java/com/icapps/niddler/interceptor/okhttp/NiddlerOkHttpInterceptor.java
@@ -325,10 +325,10 @@ public class NiddlerOkHttpInterceptor implements Interceptor {
 		return builder.build();
 	}
 
-	@Nullable
+	@NonNull
 	private static Map<String, String> buildExtraNiddlerMetadata(final int flags) {
 		if (flags == 0) {
-			return null;
+			return new HashMap<>();
 		}
 
 		final Map<String, String> extra = new HashMap<>();

--- a/niddler-lib-base/src/main/java/com/icapps/niddler/interceptor/okhttp/NiddlerOkHttpRequest.java
+++ b/niddler-lib-base/src/main/java/com/icapps/niddler/interceptor/okhttp/NiddlerOkHttpRequest.java
@@ -1,7 +1,5 @@
 package com.icapps.niddler.interceptor.okhttp;
 
-import androidx.annotation.Nullable;
-
 import com.icapps.niddler.core.NiddlerRequest;
 
 import java.io.IOException;
@@ -9,8 +7,11 @@ import java.io.OutputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.UUID;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import okhttp3.MediaType;
 import okhttp3.Protocol;
 import okhttp3.Request;
@@ -34,9 +35,12 @@ final class NiddlerOkHttpRequest implements NiddlerRequest {
 	private final StackTraceElement[] mStackTraceElements;
 	@Nullable
 	private final NiddlerOkHttpInterceptor.NiddlerRequestContext mRequestContext;
+	private final Map<String, String> mMetadata;
 
 	NiddlerOkHttpRequest(final Request request, final String requestId, @Nullable final Map<String, String> extraHeaders,
-			@Nullable final StackTraceElement[] stackTraceElements, @Nullable final NiddlerOkHttpInterceptor.NiddlerRequestContext requestContext) {
+			@Nullable final StackTraceElement[] stackTraceElements,
+			@Nullable final NiddlerOkHttpInterceptor.NiddlerRequestContext requestContext,
+			@Nullable final Map<String, String> metadata) {
 		mRequest = request;
 		mRequestId = requestId;
 		mMessageId = UUID.randomUUID().toString();
@@ -44,13 +48,24 @@ final class NiddlerOkHttpRequest implements NiddlerRequest {
 		mExtraHeaders = extraHeaders;
 		mStackTraceElements = stackTraceElements;
 		mRequestContext = requestContext;
+		mMetadata = new TreeMap<>();
+
+		if (metadata != null) {
+			mMetadata.putAll(metadata);
+		}
 	}
 
+	public void addMetadata(@NonNull final String key, @NonNull final String value) {
+		mMetadata.put(key, value);
+	}
+
+	@NonNull
 	@Override
 	public String getMessageId() {
 		return mMessageId;
 	}
 
+	@NonNull
 	@Override
 	public String getRequestId() {
 		return mRequestId;
@@ -61,11 +76,19 @@ final class NiddlerOkHttpRequest implements NiddlerRequest {
 		return mTimestamp;
 	}
 
+	@NonNull
 	@Override
 	public String getUrl() {
 		return mRequest.url().toString();
 	}
 
+	@NonNull
+	@Override
+	public Map<String, String> getMetadata() {
+		return mMetadata;
+	}
+
+	@NonNull
 	@Override
 	public Map<String, List<String>> getHeaders() {
 		final Map<String, List<String>> headers = mRequest.headers().toMultimap();
@@ -91,6 +114,7 @@ final class NiddlerOkHttpRequest implements NiddlerRequest {
 		return mStackTraceElements;
 	}
 
+	@NonNull
 	@Override
 	public String getMethod() {
 		return mRequest.method();
@@ -106,7 +130,7 @@ final class NiddlerOkHttpRequest implements NiddlerRequest {
 	}
 
 	@Override
-	public void writeBody(final OutputStream stream) {
+	public void writeBody(@NonNull final OutputStream stream) {
 		try {
 			final BufferedSink buffer = Okio.buffer(Okio.sink(stream));
 


### PR DESCRIPTION
… mode. Fixes #20

Add metadata to protocol to send agnostic metadata to the plugin. Replaces injected headers.
Check if a response was served purely from cache and mark it as such in the metadata. Fixes #19
Added extra nullability indicators to request/response interfaces
Added some missing javadocs to request/response interfaces